### PR TITLE
Fix wayland renderer lagging behind by 1 keystroke

### DIFF
--- a/lib/renderers/wayland/window.c
+++ b/lib/renderers/wayland/window.c
@@ -208,9 +208,6 @@ bm_wl_window_render(struct window *window, struct wl_display *display, const str
 {
     assert(window && menu);
 
-    if (window->frame_cb)
-        return;
-
     struct buffer *buffer;
     for (int tries = 0; tries < 2; ++tries) {
         if (!(buffer = next_buffer(window))) {


### PR DESCRIPTION
When using the wayland renderer the entries according to the second to last keystroke where displayed while the actual selected entry matched the last keystroke.
This removes skipping the buffer change in bm_wl_window_render if window->frame_cb is not NULL.
Fixes #35